### PR TITLE
fix crash caused by new GeoAlchemy2 version

### DIFF
--- a/pip-requirements.txt
+++ b/pip-requirements.txt
@@ -1,5 +1,5 @@
 GeoAlchemy>=0.6
-GeoAlchemy2>=0.2.4
+GeoAlchemy2==0.5.0
 Shapely>=1.2.13
 OWSLib==0.8.6
 lxml>=2.3


### PR DESCRIPTION
This patch fixes an issue where new versions of GeoAlchemy2 caused crashes.

We've locked the dependency to a known, working version.